### PR TITLE
Added second version of proxy

### DIFF
--- a/contracts/Forwarder2.sol
+++ b/contracts/Forwarder2.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.23;
+pragma experimental "v0.5.0";
+
+contract Forwarder2 {
+  address destination;
+
+  constructor(address contractAddress) public {
+    destination = contractAddress;
+  }
+
+  function() external payable {
+    require(msg.sig != 0x0, "function sig not specified");
+
+    address _destination = destination;
+
+    assembly {
+      calldatacopy(mload(0x40), 0, calldatasize)
+      let result := delegatecall(gas, _destination, mload(0x40), calldatasize, mload(0x40), 0)
+      returndatacopy(mload(0x40), 0, returndatasize)
+      switch result
+      case 1 { return(mload(0x40), returndatasize) }
+      default { revert(mload(0x40), returndatasize) }
+    }
+  }
+}

--- a/test/delegatecall-proxy.js
+++ b/test/delegatecall-proxy.js
@@ -1,4 +1,5 @@
 const Forwarder = artifacts.require('Forwarder')
+const Forwarder2 = artifacts.require('Forwarder2')
 const Resolver = artifacts.require('Resolver')
 const DummyContract = artifacts.require('DummyContract')
 const IDummyContract = artifacts.require('IDummyContract')
@@ -12,39 +13,63 @@ function web3GetStorageAt(address, position) {
   });
 }
 
-contract('Proxy', async () => {
+contract('Forwarder', async () => {
   let resolver;
+  let dummyContract;
   before(async () => {
-    // creating single contract from which the proxy contract will inherit storage and functions
-    const dummyContract = await DummyContract.new();
+    // creating single contract from which the forwarder contract will inherit storage and functions
+    dummyContract = await DummyContract.new();
     resolver = await Resolver.new();
     await resolver.register('increment()', dummyContract.address);
     await resolver.register('get()', dummyContract.address);
   });
 
-  it('should deploy 3 proxy contracts', async () => {
+  it('should deploy 3 forwarder contracts', async () => {
     // first
-    let proxy = await Forwarder.new();
-    await proxy.setResolver(resolver.address);
-    let dummyContractProxy = await IDummyContract.at(proxy.address);
-    await dummyContractProxy.increment();
-    let res = await dummyContractProxy.get();
+    let forwarder = await Forwarder.new();
+    await forwarder.setResolver(resolver.address);
+    let dummyContractForwarder = await IDummyContract.at(forwarder.address);
+    await dummyContractForwarder.increment();
+    let res = await dummyContractForwarder.get();
     assert.equal(res.toNumber(), 1);
 
     // second
-    proxy = await Forwarder.new();
-    await proxy.setResolver(resolver.address);
-    dummyContractProxy = await IDummyContract.at(proxy.address);
-    await dummyContractProxy.increment();
-    res = await dummyContractProxy.get();
+    forwarder = await Forwarder.new();
+    await forwarder.setResolver(resolver.address);
+    dummyContractForwarder = await IDummyContract.at(forwarder.address);
+    await dummyContractForwarder.increment();
+    res = await dummyContractForwarder.get();
     assert.equal(res.toNumber(), 1);
 
     // third
-    proxy = await Forwarder.new();
-    await proxy.setResolver(resolver.address);
-    dummyContractProxy = await IDummyContract.at(proxy.address);
-    await dummyContractProxy.increment();
-    res = await dummyContractProxy.get();
+    forwarder = await Forwarder.new();
+    await forwarder.setResolver(resolver.address);
+    dummyContractForwarder = await IDummyContract.at(forwarder.address);
+    await dummyContractForwarder.increment();
+    res = await dummyContractForwarder.get();
+    assert.equal(res.toNumber(), 1);
+  });
+
+  it('should deploy 3 forwarder contracts without resolver', async () => {
+    // first
+    let forwarder = await Forwarder2.new(dummyContract.address);
+    let dummyContractForwarder = await IDummyContract.at(forwarder.address);
+    await dummyContractForwarder.increment();
+    let res = await dummyContractForwarder.get();
+    assert.equal(res.toNumber(), 1);
+
+    // second
+    forwarder = await Forwarder2.new(dummyContract.address);
+    dummyContractForwarder = await IDummyContract.at(forwarder.address);
+    await dummyContractForwarder.increment();
+    res = await dummyContractForwarder.get();
+    assert.equal(res.toNumber(), 1);
+
+    // third
+    forwarder = await Forwarder2.new(dummyContract.address);
+    dummyContractForwarder = await IDummyContract.at(forwarder.address);
+    await dummyContractForwarder.increment();
+    res = await dummyContractForwarder.get();
     assert.equal(res.toNumber(), 1);
   });
 


### PR DESCRIPTION
Version with constructor cuts another 100k of gas. Now deployment of forwarder is 170k compared to previous 270k.
To cut gas costs even more, the only way is to hardcode the address of deployed implementation contract, but im not sure if our use case can allow that.

2 thing to note:
- first storage variable in `DummyContract.sol` have different purpose from first storage variable in `Forwarder2.sol`, but they are the same size so they both take the whole first slot, so it doesn't make any problems, but of course this should not be done in real world smart contracts
- constructor in `DummyContract.sol` is not supported by proxy, but here it does not create any problem because `count` variable already has `0` default value, and of course constructors should not be used in real world with this setup